### PR TITLE
Add SwiftUI UUID generator MVP

### DIFF
--- a/iOS/UUID_Gen/UUID_Gen/ContentView.swift
+++ b/iOS/UUID_Gen/UUID_Gen/ContentView.swift
@@ -1,21 +1,41 @@
-//
-//  ContentView.swift
-//  UUID_Gen
-//
-//  Created by eightman on 2025/10/05.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var store = UuidStore()
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        TabView {
+            NavigationStack {
+                GeneratorView()
+                    .environmentObject(store)
+            }
+            .tabItem {
+                Label("生成", systemImage: "wand.and.stars")
+            }
+
+            NavigationStack {
+                HistoryView()
+                    .environmentObject(store)
+            }
+            .tabItem {
+                Label("履歴", systemImage: "clock")
+            }
+
+            NavigationStack {
+                StoreView()
+                    .environmentObject(store)
+            }
+            .tabItem {
+                Label("Pro", systemImage: "crown")
+            }
+
+            NavigationStack {
+                SettingsView()
+            }
+            .tabItem {
+                Label("設定", systemImage: "gearshape")
+            }
         }
-        .padding()
     }
 }
 

--- a/iOS/UUID_Gen/UUID_Gen/LimitLogic.swift
+++ b/iOS/UUID_Gen/UUID_Gen/LimitLogic.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct LimitState {
+    let isPro: Bool
+    let baseLimit: Int
+    let bonusActive: Int
+
+    var capacity: Int {
+        isPro ? Int.max : baseLimit + bonusActive
+    }
+
+    func canAdd(currentCount: Int) -> Bool {
+        currentCount < capacity
+    }
+}
+
+struct LimitConstants {
+    static let baseLimit = 10
+    static let maxBonus = 5
+    static let bonusDuration: TimeInterval = 24 * 60 * 60
+}

--- a/iOS/UUID_Gen/UUID_Gen/Persistence.swift
+++ b/iOS/UUID_Gen/UUID_Gen/Persistence.swift
@@ -1,0 +1,151 @@
+import CoreData
+import Foundation
+
+final class PersistenceController {
+    static let shared = PersistenceController()
+
+    let container: NSPersistentContainer
+
+    init(inMemory: Bool = false) {
+        let model = Self.makeModel()
+        container = NSPersistentContainer(name: "UUIDGen", managedObjectModel: model)
+        if inMemory {
+            container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        }
+        container.loadPersistentStores { _, error in
+            if let error = error {
+                fatalError("Unresolved error: \(error)")
+            }
+        }
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        container.viewContext.automaticallyMergesChangesFromParent = true
+    }
+
+    private static func makeModel() -> NSManagedObjectModel {
+        let model = NSManagedObjectModel()
+
+        // UuidItemEntity
+        let uuidEntity = NSEntityDescription()
+        uuidEntity.name = "UuidItemEntity"
+        uuidEntity.managedObjectClassName = NSStringFromClass(UuidItemEntity.self)
+
+        let uuidId = NSAttributeDescription()
+        uuidId.name = "id"
+        uuidId.attributeType = .stringAttributeType
+        uuidId.isOptional = false
+
+        let uuidValue = NSAttributeDescription()
+        uuidValue.name = "value"
+        uuidValue.attributeType = .stringAttributeType
+        uuidValue.isOptional = false
+
+        let uuidVersion = NSAttributeDescription()
+        uuidVersion.name = "version"
+        uuidVersion.attributeType = .stringAttributeType
+        uuidVersion.isOptional = false
+
+        let uuidCreatedAt = NSAttributeDescription()
+        uuidCreatedAt.name = "createdAt"
+        uuidCreatedAt.attributeType = .dateAttributeType
+        uuidCreatedAt.isOptional = false
+
+        let uuidLabel = NSAttributeDescription()
+        uuidLabel.name = "label"
+        uuidLabel.attributeType = .stringAttributeType
+        uuidLabel.isOptional = true
+
+        let uuidNamespace = NSAttributeDescription()
+        uuidNamespace.name = "namespace"
+        uuidNamespace.attributeType = .stringAttributeType
+        uuidNamespace.isOptional = true
+
+        let uuidName = NSAttributeDescription()
+        uuidName.name = "name"
+        uuidName.attributeType = .stringAttributeType
+        uuidName.isOptional = true
+
+        let uuidStyleFlags = NSAttributeDescription()
+        uuidStyleFlags.name = "styleFlags"
+        uuidStyleFlags.attributeType = .integer64AttributeType
+        uuidStyleFlags.isOptional = false
+        uuidStyleFlags.defaultValue = 0
+
+        uuidEntity.properties = [uuidId, uuidValue, uuidVersion, uuidCreatedAt, uuidLabel, uuidNamespace, uuidName, uuidStyleFlags]
+
+        // BonusSlotEntity
+        let bonusEntity = NSEntityDescription()
+        bonusEntity.name = "BonusSlotEntity"
+        bonusEntity.managedObjectClassName = NSStringFromClass(BonusSlotEntity.self)
+
+        let bonusId = NSAttributeDescription()
+        bonusId.name = "id"
+        bonusId.attributeType = .stringAttributeType
+        bonusId.isOptional = false
+
+        let bonusExpiresAt = NSAttributeDescription()
+        bonusExpiresAt.name = "expiresAt"
+        bonusExpiresAt.attributeType = .dateAttributeType
+        bonusExpiresAt.isOptional = false
+
+        bonusEntity.properties = [bonusId, bonusExpiresAt]
+
+        // EntitlementEntity
+        let entitlementEntity = NSEntityDescription()
+        entitlementEntity.name = "EntitlementEntity"
+        entitlementEntity.managedObjectClassName = NSStringFromClass(EntitlementEntity.self)
+
+        let entitlementId = NSAttributeDescription()
+        entitlementId.name = "id"
+        entitlementId.attributeType = .stringAttributeType
+        entitlementId.isOptional = false
+
+        let entitlementIsPro = NSAttributeDescription()
+        entitlementIsPro.name = "isPro"
+        entitlementIsPro.attributeType = .booleanAttributeType
+        entitlementIsPro.isOptional = false
+        entitlementIsPro.defaultValue = false
+
+        let entitlementProSince = NSAttributeDescription()
+        entitlementProSince.name = "proSince"
+        entitlementProSince.attributeType = .dateAttributeType
+        entitlementProSince.isOptional = true
+
+        let entitlementLastSync = NSAttributeDescription()
+        entitlementLastSync.name = "lastSyncAt"
+        entitlementLastSync.attributeType = .dateAttributeType
+        entitlementLastSync.isOptional = true
+
+        entitlementEntity.properties = [entitlementId, entitlementIsPro, entitlementProSince, entitlementLastSync]
+
+        model.entities = [uuidEntity, bonusEntity, entitlementEntity]
+        return model
+    }
+}
+
+// MARK: - Managed Object subclasses
+
+@objc(UuidItemEntity)
+final class UuidItemEntity: NSManagedObject {
+    @NSManaged var id: String
+    @NSManaged var value: String
+    @NSManaged var version: String
+    @NSManaged var createdAt: Date
+    @NSManaged var label: String?
+    @NSManaged var namespace: String?
+    @NSManaged var name: String?
+    @NSManaged var styleFlags: Int64
+}
+
+@objc(BonusSlotEntity)
+final class BonusSlotEntity: NSManagedObject {
+    @NSManaged var id: String
+    @NSManaged var expiresAt: Date
+}
+
+@objc(EntitlementEntity)
+final class EntitlementEntity: NSManagedObject {
+    @NSManaged var id: String
+    @NSManaged var isPro: Bool
+    @NSManaged var proSince: Date?
+    @NSManaged var lastSyncAt: Date?
+}

--- a/iOS/UUID_Gen/UUID_Gen/UUIDGeneration.swift
+++ b/iOS/UUID_Gen/UUID_Gen/UUIDGeneration.swift
@@ -1,0 +1,145 @@
+import CryptoKit
+import Foundation
+import Security
+
+enum UUIDVersion: String, CaseIterable, Identifiable {
+    case v4 = "v4"
+    case v5 = "v5"
+    case v7 = "v7"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .v4: return "UUID v4"
+        case .v5: return "UUID v5"
+        case .v7: return "UUID v7"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .v4: return "ランダム値ベース"
+        case .v5: return "名前空間 + 名前 (SHA-1)"
+        case .v7: return "時刻ベース (RFC 9562)"
+        }
+    }
+}
+
+struct UuidFormatOptions: OptionSet {
+    let rawValue: Int64
+
+    static let hyphen = UuidFormatOptions(rawValue: 1 << 0)
+    static let uppercase = UuidFormatOptions(rawValue: 1 << 1)
+    static let braces = UuidFormatOptions(rawValue: 1 << 2)
+
+    static let `default`: UuidFormatOptions = [.hyphen]
+}
+
+struct GeneratedUuid: Identifiable {
+    let id: String
+    let value: UUID
+    let version: UUIDVersion
+    let createdAt: Date
+    let namespace: UUID?
+    let name: String?
+    let format: UuidFormatOptions
+
+    init(value: UUID, version: UUIDVersion, createdAt: Date = Date(), namespace: UUID? = nil, name: String? = nil, format: UuidFormatOptions = .default) {
+        self.id = value.uuidString
+        self.value = value
+        self.version = version
+        self.createdAt = createdAt
+        self.namespace = namespace
+        self.name = name
+        self.format = format
+    }
+}
+
+enum UUIDGenerationError: Error {
+    case invalidNamespace
+    case invalidName
+}
+
+enum UUIDGenerator {
+    static func generate(version: UUIDVersion, namespaceString: String?, name: String?, now: Date = Date()) throws -> GeneratedUuid {
+        switch version {
+        case .v4:
+            return GeneratedUuid(value: UUID(), version: .v4, createdAt: now)
+        case .v5:
+            guard let namespaceString, let namespace = UUID(uuidString: namespaceString) else {
+                throw UUIDGenerationError.invalidNamespace
+            }
+            guard let name, !name.isEmpty else {
+                throw UUIDGenerationError.invalidName
+            }
+            let uuid = uuidV5(namespace: namespace, name: name)
+            return GeneratedUuid(value: uuid, version: .v5, createdAt: now, namespace: namespace, name: name)
+        case .v7:
+            let uuid = uuidV7(now: UInt64(now.timeIntervalSince1970 * 1000))
+            return GeneratedUuid(value: uuid, version: .v7, createdAt: now)
+        }
+    }
+
+    static func uuidV5(namespace: UUID, name: String) -> UUID {
+        let namespaceBytes = withUnsafeBytes(of: namespace.uuid) { Data($0) }
+        let nameBytes = Data(name.utf8)
+        var data = Data()
+        data.append(namespaceBytes)
+        data.append(nameBytes)
+
+        let hash = Insecure.SHA1.hash(data: data)
+        var bytes = Array(hash)
+
+        bytes[6] = (bytes[6] & 0x0F) | 0x50
+        bytes[8] = (bytes[8] & 0x3F) | 0x80
+
+        return UUID(uuid: (bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]))
+    }
+
+    static func uuidV7(now: UInt64) -> UUID {
+        var randomBytes = [UInt8](repeating: 0, count: 10)
+        let status = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
+        if status != errSecSuccess {
+            for i in 0..<randomBytes.count {
+                randomBytes[i] = UInt8.random(in: UInt8.min...UInt8.max)
+            }
+        }
+
+        var bytes = [UInt8](repeating: 0, count: 16)
+        bytes[0] = UInt8((now >> 40) & 0xFF)
+        bytes[1] = UInt8((now >> 32) & 0xFF)
+        bytes[2] = UInt8((now >> 24) & 0xFF)
+        bytes[3] = UInt8((now >> 16) & 0xFF)
+        bytes[4] = UInt8((now >> 8) & 0xFF)
+        bytes[5] = UInt8(now & 0xFF)
+
+        bytes[6] = (randomBytes[0] & 0x0F) | 0x70
+        bytes[7] = randomBytes[1]
+
+        bytes[8] = (randomBytes[2] & 0x3F) | 0x80
+        bytes[9] = randomBytes[3]
+
+        for i in 0..<6 {
+            bytes[10 + i] = randomBytes[4 + i]
+        }
+
+        return UUID(uuid: (bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7], bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]))
+    }
+}
+
+func format(uuid: UUID, options: UuidFormatOptions) -> String {
+    var string = uuid.uuidString
+    if !options.contains(.hyphen) {
+        string = string.replacingOccurrences(of: "-", with: "")
+    }
+    if options.contains(.uppercase) {
+        string = string.uppercased()
+    } else {
+        string = string.lowercased()
+    }
+    if options.contains(.braces) {
+        string = "{\(string)}"
+    }
+    return string
+}

--- a/iOS/UUID_Gen/UUID_Gen/UUID_GenApp.swift
+++ b/iOS/UUID_Gen/UUID_Gen/UUID_GenApp.swift
@@ -12,6 +12,7 @@ struct UUID_GenApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(\.managedObjectContext, PersistenceController.shared.container.viewContext)
         }
     }
 }

--- a/iOS/UUID_Gen/UUID_Gen/UuidStore.swift
+++ b/iOS/UUID_Gen/UUID_Gen/UuidStore.swift
@@ -1,0 +1,236 @@
+import CoreData
+import Foundation
+import SwiftUI
+
+struct UuidRecord: Identifiable, Hashable {
+    let id: String
+    let rawValue: String
+    let version: UUIDVersion
+    let createdAt: Date
+    let label: String?
+    let namespace: String?
+    let name: String?
+    let formatOptions: UuidFormatOptions
+
+    var formattedValue: String {
+        format(uuid: UUID(uuidString: rawValue) ?? UUID(), options: formatOptions)
+    }
+}
+
+struct BonusSlot: Identifiable, Hashable {
+    let id: String
+    let expiresAt: Date
+}
+
+struct EntitlementState {
+    var isPro: Bool
+    var proSince: Date?
+    var lastSyncAt: Date?
+}
+
+@MainActor
+final class UuidStore: ObservableObject {
+    @Published private(set) var items: [UuidRecord] = []
+    @Published private(set) var bonusSlots: [BonusSlot] = []
+    @Published private(set) var entitlement: EntitlementState
+    @Published private(set) var limitState: LimitState
+
+    private let container: NSPersistentContainer
+    private var context: NSManagedObjectContext { container.viewContext }
+
+    init(container: NSPersistentContainer = PersistenceController.shared.container) {
+        self.container = container
+        let entitlement = Self.loadEntitlement(context: container.viewContext)
+        self.entitlement = entitlement
+        self.limitState = LimitState(isPro: entitlement.isPro, baseLimit: LimitConstants.baseLimit, bonusActive: 0)
+        Task {
+            await refresh()
+        }
+    }
+
+    func refresh() async {
+        await purgeExpiredBonusSlots()
+        let items = await fetchItems()
+        let bonus = await fetchBonusSlots()
+        await MainActor.run {
+            self.items = items
+            self.bonusSlots = bonus
+            self.limitState = LimitState(isPro: entitlement.isPro, baseLimit: LimitConstants.baseLimit, bonusActive: bonus.count)
+        }
+    }
+
+    func generateAndSave(version: UUIDVersion, namespace: String?, name: String?, label: String?, formatOptions: UuidFormatOptions) async throws {
+        await refresh()
+        guard limitState.canAdd(currentCount: items.count) else {
+            throw NSError(domain: "UuidStore", code: 1, userInfo: [NSLocalizedDescriptionKey: "保存上限に達しました。"])
+        }
+        let generated = try UUIDGenerator.generate(version: version, namespaceString: namespace, name: name)
+        try await save(generated: generated, label: label, formatOptions: formatOptions)
+    }
+
+    func save(generated: GeneratedUuid, label: String?, formatOptions: UuidFormatOptions) async throws {
+        let context = context
+        try await context.perform {
+            let entity = UuidItemEntity(context: context)
+            entity.id = generated.id
+            entity.value = generated.value.uuidString
+            entity.version = generated.version.rawValue
+            entity.createdAt = generated.createdAt
+            entity.label = label
+            entity.namespace = generated.namespace?.uuidString
+            entity.name = generated.name
+            entity.styleFlags = formatOptions.rawValue
+            try context.save()
+        }
+        await refresh()
+    }
+
+    func delete(_ record: UuidRecord) async {
+        let context = context
+        await context.perform {
+            let request: NSFetchRequest<UuidItemEntity> = UuidItemEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "id == %@", record.id)
+            request.fetchLimit = 1
+            if let entity = try? context.fetch(request).first {
+                context.delete(entity)
+            }
+            try? context.save()
+        }
+        await refresh()
+    }
+
+    func removeAll() async {
+        let context = context
+        await context.perform {
+            let fetch: NSFetchRequest<NSFetchRequestResult> = UuidItemEntity.fetchRequest()
+            let delete = NSBatchDeleteRequest(fetchRequest: fetch)
+            _ = try? context.execute(delete)
+            try? context.save()
+        }
+        await refresh()
+    }
+
+    func addBonusSlot() async {
+        await purgeExpiredBonusSlots()
+        guard bonusSlots.count < LimitConstants.maxBonus else { return }
+        let context = context
+        await context.perform {
+            let entity = BonusSlotEntity(context: context)
+            entity.id = UUID().uuidString
+            entity.expiresAt = Date().addingTimeInterval(LimitConstants.bonusDuration)
+            try? context.save()
+        }
+        await refresh()
+    }
+
+    func purgeExpiredBonusSlots() async {
+        let context = context
+        await context.perform {
+            let request: NSFetchRequest<BonusSlotEntity> = BonusSlotEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "expiresAt < %@", Date() as NSDate)
+            if let expired = try? context.fetch(request) {
+                for entity in expired {
+                    context.delete(entity)
+                }
+                if context.hasChanges {
+                    try? context.save()
+                }
+            }
+        }
+    }
+
+    func togglePro() async {
+        entitlement.isPro.toggle()
+        if entitlement.isPro {
+            entitlement.proSince = Date()
+        } else {
+            entitlement.proSince = nil
+        }
+        await saveEntitlement()
+        await refresh()
+    }
+
+    private static func loadEntitlement(context: NSManagedObjectContext) -> EntitlementState {
+        let request: NSFetchRequest<EntitlementEntity> = EntitlementEntity.fetchRequest()
+        request.fetchLimit = 1
+        if let entity = try? context.fetch(request).first {
+            return EntitlementState(isPro: entity.isPro, proSince: entity.proSince, lastSyncAt: entity.lastSyncAt)
+        }
+        let newEntity = EntitlementEntity(context: context)
+        newEntity.id = "primary"
+        newEntity.isPro = false
+        newEntity.proSince = nil
+        newEntity.lastSyncAt = nil
+        try? context.save()
+        return EntitlementState(isPro: false, proSince: nil, lastSyncAt: nil)
+    }
+
+    private func saveEntitlement() async {
+        let context = context
+        await context.perform {
+            let request: NSFetchRequest<EntitlementEntity> = EntitlementEntity.fetchRequest()
+            request.fetchLimit = 1
+            let entity = (try? context.fetch(request).first) ?? EntitlementEntity(context: context)
+            entity.id = "primary"
+            entity.isPro = entitlement.isPro
+            entity.proSince = entitlement.proSince
+            entity.lastSyncAt = Date()
+            try? context.save()
+        }
+    }
+
+    private func fetchItems() async -> [UuidRecord] {
+        let context = context
+        return await context.perform {
+            let request: NSFetchRequest<UuidItemEntity> = UuidItemEntity.fetchRequest()
+            let sort = NSSortDescriptor(key: "createdAt", ascending: false)
+            request.sortDescriptors = [sort]
+            let entities = (try? context.fetch(request)) ?? []
+            return entities.map { entity in
+                UuidRecord(
+                    id: entity.id,
+                    rawValue: entity.value,
+                    version: UUIDVersion(rawValue: entity.version) ?? .v4,
+                    createdAt: entity.createdAt,
+                    label: entity.label,
+                    namespace: entity.namespace,
+                    name: entity.name,
+                    formatOptions: UuidFormatOptions(rawValue: entity.styleFlags)
+                )
+            }
+        }
+    }
+
+    private func fetchBonusSlots() async -> [BonusSlot] {
+        let context = context
+        return await context.perform {
+            let request: NSFetchRequest<BonusSlotEntity> = BonusSlotEntity.fetchRequest()
+            let sort = NSSortDescriptor(key: "expiresAt", ascending: true)
+            request.sortDescriptors = [sort]
+            let entities = (try? context.fetch(request)) ?? []
+            return entities.map { entity in
+                BonusSlot(id: entity.id, expiresAt: entity.expiresAt)
+            }
+        }
+    }
+}
+
+// MARK: - FetchRequest helpers
+
+extension UuidItemEntity {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<UuidItemEntity> {
+        NSFetchRequest<UuidItemEntity>(entityName: "UuidItemEntity")
+    }
+}
+
+extension BonusSlotEntity {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<BonusSlotEntity> {
+        NSFetchRequest<BonusSlotEntity>(entityName: "BonusSlotEntity")
+    }
+}
+
+extension EntitlementEntity {
+    @nonobjc class func fetchRequest() -> NSFetchRequest<EntitlementEntity> {
+        NSFetchRequest<EntitlementEntity>(entityName: "EntitlementEntity")
+    }
+}

--- a/iOS/UUID_Gen/UUID_Gen/Views/DetailView.swift
+++ b/iOS/UUID_Gen/UUID_Gen/Views/DetailView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct DetailView: View {
+    let record: UuidRecord
+
+    var body: some View {
+        Form {
+            Section("UUID") {
+                Text(record.formattedValue)
+                    .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
+            }
+            Section("メタ情報") {
+                LabeledContent("バージョン", value: record.version.rawValue.uppercased())
+                LabeledContent("作成日時", value: record.createdAt.formatted(date: .abbreviated, time: .standard))
+                if let namespace = record.namespace {
+                    LabeledContent("Namespace", value: namespace)
+                }
+                if let name = record.name {
+                    LabeledContent("Name", value: name)
+                }
+                if let label = record.label {
+                    LabeledContent("ラベル", value: label)
+                }
+            }
+        }
+        .navigationTitle("詳細")
+    }
+}

--- a/iOS/UUID_Gen/UUID_Gen/Views/GeneratorView.swift
+++ b/iOS/UUID_Gen/UUID_Gen/Views/GeneratorView.swift
@@ -1,0 +1,206 @@
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+struct GeneratorView: View {
+    @EnvironmentObject private var store: UuidStore
+
+    @AppStorage("defaultVersion") private var defaultVersionRaw: String = UUIDVersion.v7.rawValue
+    @AppStorage("formatHyphen") private var defaultHyphen: Bool = true
+    @AppStorage("formatUppercase") private var defaultUppercase: Bool = false
+    @AppStorage("formatBraces") private var defaultBraces: Bool = false
+
+    @State private var selectedVersion: UUIDVersion = .v7
+    @State private var namespace: String = ""
+    @State private var name: String = ""
+    @State private var label: String = ""
+    @State private var generated: GeneratedUuid?
+    @State private var formattedValue: String = ""
+    @State private var isGenerating: Bool = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        Form {
+            Section("バージョン") {
+                Picker("UUID バージョン", selection: $selectedVersion) {
+                    ForEach(UUIDVersion.allCases) { version in
+                        VStack(alignment: .leading) {
+                            Text(version.title)
+                            Text(version.description)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                        .tag(version)
+                    }
+                }
+                .pickerStyle(.inline)
+            }
+
+            if selectedVersion == .v5 {
+                Section("名前空間 v5") {
+                    TextField("Namespace UUID", text: $namespace)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                    TextField("Name", text: $name)
+                        .autocorrectionDisabled()
+                }
+            }
+
+            Section("整形オプション") {
+                Toggle("ハイフンを含める", isOn: Binding(
+                    get: { formatOptions.contains(.hyphen) },
+                    set: { updateOption($0, option: .hyphen) }
+                ))
+                Toggle("大文字にする", isOn: Binding(
+                    get: { formatOptions.contains(.uppercase) },
+                    set: { updateOption($0, option: .uppercase) }
+                ))
+                Toggle("{} を付与", isOn: Binding(
+                    get: { formatOptions.contains(.braces) },
+                    set: { updateOption($0, option: .braces) }
+                ))
+            }
+
+            Section("ラベル (任意)") {
+                TextField("メモ", text: $label)
+            }
+
+            Section {
+                Button {
+                    Task { await generate() }
+                } label: {
+                    Label("UUIDを生成", systemImage: "sparkles")
+                }
+                .disabled(isGenerating)
+            }
+
+            if let generated {
+                Section("結果") {
+                    Text(formattedValue)
+                        .font(.system(.title3, design: .monospaced))
+                        .textSelection(.enabled)
+                        .contextMenu {
+                            Button("コピー") { copyResult() }
+                        }
+                    resultInfoView(generated: generated)
+                    HStack {
+                        Button {
+                            copyResult()
+                        } label: {
+                            Label("コピー", systemImage: "doc.on.doc")
+                        }
+                        Spacer()
+                        ShareLink(item: formattedValue, preview: SharePreview("UUID", image: Image(systemName: "square.on.square"))) {
+                            Label("共有", systemImage: "square.and.arrow.up")
+                        }
+                    }
+                    Button {
+                        Task { await saveCurrent() }
+                    } label: {
+                        Label("保存", systemImage: "tray.and.arrow.down")
+                    }
+                    .disabled(!store.limitState.canAdd(currentCount: store.items.count))
+                }
+            }
+
+            Section("保存可能数") {
+                if store.entitlement.isPro {
+                    Text("保存上限: 無制限")
+                } else {
+                    Text("保存数: \(store.items.count) / \(store.limitState.capacity)")
+                    if store.bonusSlots.count > 0 {
+                        Text("ボーナス枠: \(store.bonusSlots.count) / \(LimitConstants.maxBonus)")
+                    }
+                }
+                if !store.bonusSlots.isEmpty {
+                    ForEach(store.bonusSlots) { slot in
+                        Text("ボーナス枠 有効期限: \(slot.expiresAt.formatted(date: .omitted, time: .shortened))")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .navigationTitle("UUID 生成")
+        .task {
+            selectedVersion = UUIDVersion(rawValue: defaultVersionRaw) ?? .v7
+        }
+        .alert("エラー", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { _ in errorMessage = nil }
+        ), actions: {
+            Button("OK", role: .cancel) { }
+        }, message: {
+            Text(errorMessage ?? "")
+        })
+    }
+
+    private var formatOptions: UuidFormatOptions {
+        var options = UuidFormatOptions()
+        if defaultHyphen { options.insert(.hyphen) }
+        if defaultUppercase { options.insert(.uppercase) }
+        if defaultBraces { options.insert(.braces) }
+        return options
+    }
+
+    private func updateOption(_ newValue: Bool, option: UuidFormatOptions) {
+        switch option {
+        case .hyphen: defaultHyphen = newValue
+        case .uppercase: defaultUppercase = newValue
+        case .braces: defaultBraces = newValue
+        default: break
+        }
+    }
+
+    @MainActor
+    private func generate() async {
+        isGenerating = true
+        defer { isGenerating = false }
+        do {
+            let result = try UUIDGenerator.generate(version: selectedVersion, namespaceString: namespace.isEmpty ? nil : namespace, name: name.isEmpty ? nil : name)
+            generated = result
+            formattedValue = format(uuid: result.value, options: formatOptions)
+            defaultVersionRaw = selectedVersion.rawValue
+        } catch UUIDGenerationError.invalidNamespace {
+            errorMessage = "名前空間 UUID が不正です"
+        } catch UUIDGenerationError.invalidName {
+            errorMessage = "Name を入力してください"
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func saveCurrent() async {
+        guard let generated else { return }
+        do {
+            try await store.save(generated: generated, label: label.isEmpty ? nil : label, formatOptions: formatOptions)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func copyResult() {
+        guard !formattedValue.isEmpty else { return }
+        #if canImport(UIKit)
+        UIPasteboard.general.string = formattedValue
+        #endif
+    }
+
+    @ViewBuilder
+    private func resultInfoView(generated: GeneratedUuid) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("バージョン: \(generated.version.rawValue.uppercased())")
+            Text("生成時刻: \(generated.createdAt.formatted(date: .abbreviated, time: .standard))")
+            if let namespace = generated.namespace?.uuidString {
+                Text("Namespace: \(namespace)")
+            }
+            if let name = generated.name {
+                Text("Name: \(name)")
+            }
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+}

--- a/iOS/UUID_Gen/UUID_Gen/Views/HistoryView.swift
+++ b/iOS/UUID_Gen/UUID_Gen/Views/HistoryView.swift
@@ -1,0 +1,91 @@
+import SwiftUI
+
+struct HistoryView: View {
+    @EnvironmentObject private var store: UuidStore
+    @State private var errorMessage: String?
+
+    var body: some View {
+        List {
+            summarySection
+            if store.items.isEmpty {
+                ContentUnavailableView("保存された UUID はありません", systemImage: "tray") {
+                    Text("生成画面から保存できます")
+                }
+            } else {
+                ForEach(store.items) { item in
+                    NavigationLink(value: item) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(item.formattedValue)
+                                .font(.system(.body, design: .monospaced))
+                            HStack(spacing: 12) {
+                                Text(item.version.rawValue.uppercased())
+                                Text(item.createdAt.formatted(date: .abbreviated, time: .shortened))
+                            }
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            if let label = item.label, !label.isEmpty {
+                                Text(label)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            Task { await store.delete(item) }
+                        } label: {
+                            Label("削除", systemImage: "trash")
+                        }
+                        ShareLink(item: item.formattedValue) {
+                            Label("共有", systemImage: "square.and.arrow.up")
+                        }
+                        .tint(.blue)
+                    }
+                }
+            }
+        }
+        .navigationDestination(for: UuidRecord.self) { item in
+            DetailView(record: item)
+        }
+        .navigationTitle("履歴")
+        .toolbar {
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                if !store.entitlement.isPro {
+                    Button("広告で +1") {
+                        Task { await store.addBonusSlot() }
+                    }
+                }
+                Button(role: .destructive) {
+                    Task { await store.removeAll() }
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .disabled(store.items.isEmpty)
+            }
+        }
+        .alert("エラー", isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { _ in errorMessage = nil }
+        )) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+        .refreshable {
+            await store.refresh()
+        }
+    }
+
+    private var summarySection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 4) {
+                if store.entitlement.isPro {
+                    Text("保存数: \(store.items.count)")
+                } else {
+                    Text("保存数: \(store.items.count) / \(store.limitState.capacity)")
+                    Text("ボーナス枠: \(store.bonusSlots.count) / \(LimitConstants.maxBonus)")
+                }
+            }
+        }
+    }
+}

--- a/iOS/UUID_Gen/UUID_Gen/Views/SettingsView.swift
+++ b/iOS/UUID_Gen/UUID_Gen/Views/SettingsView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @AppStorage("defaultVersion") private var defaultVersionRaw: String = UUIDVersion.v7.rawValue
+    @AppStorage("formatHyphen") private var defaultHyphen: Bool = true
+    @AppStorage("formatUppercase") private var defaultUppercase: Bool = false
+    @AppStorage("formatBraces") private var defaultBraces: Bool = false
+
+    var body: some View {
+        Form {
+            Section("既定の生成設定") {
+                Picker("デフォルトバージョン", selection: $defaultVersionRaw) {
+                    ForEach(UUIDVersion.allCases) { version in
+                        Text(version.title).tag(version.rawValue)
+                    }
+                }
+                Toggle("ハイフンを含める", isOn: $defaultHyphen)
+                Toggle("大文字にする", isOn: $defaultUppercase)
+                Toggle("{} を付与", isOn: $defaultBraces)
+            }
+
+            Section("情報") {
+                LabeledContent("アプリバージョン", value: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")
+                LabeledContent("ビルド", value: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1")
+            }
+        }
+        .navigationTitle("設定")
+    }
+}

--- a/iOS/UUID_Gen/UUID_Gen/Views/StoreView.swift
+++ b/iOS/UUID_Gen/UUID_Gen/Views/StoreView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct StoreView: View {
+    @EnvironmentObject private var store: UuidStore
+    @State private var isProcessing = false
+    @State private var message: String?
+
+    var body: some View {
+        Form {
+            Section("UUID Pro") {
+                Text("保存数無制限、広告非表示（予定）")
+                Button {
+                    Task { await togglePro() }
+                } label: {
+                    if isProcessing {
+                        ProgressView()
+                    } else {
+                        Text(store.entitlement.isPro ? "Pro を解除 (開発用)" : "Pro を購入 (テスト)")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isProcessing)
+                Text("StoreKit 2 の実装まではローカルで状態を切り替えます")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let proSince = store.entitlement.proSince {
+                Section("購入情報") {
+                    Text("Pro since: \(proSince.formatted(date: .abbreviated, time: .shortened))")
+                }
+            }
+
+            Section("ボーナス枠") {
+                if store.bonusSlots.isEmpty {
+                    Text("ボーナス枠はありません")
+                } else {
+                    ForEach(store.bonusSlots) { slot in
+                        Text("有効期限: \(slot.expiresAt.formatted(date: .omitted, time: .shortened))")
+                    }
+                }
+                Button {
+                    Task { await store.addBonusSlot() }
+                } label: {
+                    Label("広告視聴をシミュレート", systemImage: "play.rectangle")
+                }
+                .disabled(store.bonusSlots.count >= LimitConstants.maxBonus)
+            }
+        }
+        .navigationTitle("ストア")
+        .alert("メッセージ", isPresented: Binding(
+            get: { message != nil },
+            set: { _ in message = nil }
+        )) {
+            Button("OK", role: .cancel) { }
+        } message: {
+            Text(message ?? "")
+        }
+    }
+
+    private func togglePro() async {
+        guard !isProcessing else { return }
+        isProcessing = true
+        await store.togglePro()
+        isProcessing = false
+        message = store.entitlement.isPro ? "Pro を有効化しました" : "Pro を解除しました"
+    }
+}


### PR DESCRIPTION
## Summary
- implement a Core Data stack, domain store, and limit management for the Swift UUID generator
- add SwiftUI screens for generation, history, detail, store simulation, and settings following the dual-native plan
- supply UUID v4/v5/v7 creation utilities with formatting controls and persistence integration

## Testing
- not run (iOS tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1ef2709a08322b1b090822574802e