### PR TITLE
Fix UuidStore observable object errors

### DIFF
--- a/iOS/UUID_Gen/UUID_Gen/UUID_GenApp.swift
+++ b/iOS/UUID_Gen/UUID_Gen/UUID_GenApp.swift
@@ -5,6 +5,7 @@
 //  Created by eightman on 2025/10/05.
 //
 
+import CoreData
 import SwiftUI
 
 @main

--- a/iOS/UUID_Gen/UUID_Gen/UuidStore.swift
+++ b/iOS/UUID_Gen/UUID_Gen/UuidStore.swift
@@ -1,3 +1,4 @@
+import Combine
 import CoreData
 import Foundation
 import SwiftUI
@@ -14,6 +15,10 @@ struct UuidRecord: Identifiable, Hashable {
 
     var formattedValue: String {
         format(uuid: UUID(uuidString: rawValue) ?? UUID(), options: formatOptions)
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }
 
@@ -172,8 +177,8 @@ final class UuidStore: ObservableObject {
             request.fetchLimit = 1
             let entity = (try? context.fetch(request).first) ?? EntitlementEntity(context: context)
             entity.id = "primary"
-            entity.isPro = entitlement.isPro
-            entity.proSince = entitlement.proSince
+            entity.isPro = self.entitlement.isPro
+            entity.proSince = self.entitlement.proSince
             entity.lastSyncAt = Date()
             try? context.save()
         }

--- a/iOS/UUID_Gen/UUID_Gen/Views/HistoryView.swift
+++ b/iOS/UUID_Gen/UUID_Gen/Views/HistoryView.swift
@@ -8,9 +8,11 @@ struct HistoryView: View {
         List {
             summarySection
             if store.items.isEmpty {
-                ContentUnavailableView("保存された UUID はありません", systemImage: "tray") {
-                    Text("生成画面から保存できます")
-                }
+                ContentUnavailableView(
+                    "保存された UUID はありません",
+                    systemImage: "tray",
+                    description: Text("生成画面から保存できます")
+                )
             } else {
                 ForEach(store.items) { item in
                     NavigationLink(value: item) {


### PR DESCRIPTION
## Summary
- import Combine and add a deterministic Hashable implementation to UuidRecord so UuidStore can conform to ObservableObject
- reference self when persisting entitlement to satisfy capture requirements
- adjust HistoryView’s empty state initializer and add the missing CoreData import for UUID_GenApp

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1f1d88b6c8322b64382d10865d41d