### PR TITLE
Add floating generate button and duplicate save guard

### DIFF
--- a/Android/app/src/main/java/com/furinlab/eightman/uuid_gen/MainActivity.kt
+++ b/Android/app/src/main/java/com/furinlab/eightman/uuid_gen/MainActivity.kt
@@ -33,6 +33,8 @@ class MainActivity : ComponentActivity() {
                     onDelete = viewModel::deleteItem,
                     onTogglePro = viewModel::togglePro,
                     onGrantBonus = viewModel::grantBonusSlot,
+                    onDismissGeneratedDialog = viewModel::dismissGeneratedDialog,
+                    onDismissError = viewModel::dismissError,
                 )
             }
         }

--- a/Android/app/src/main/java/com/furinlab/eightman/uuid_gen/data/local/UuidItemDao.kt
+++ b/Android/app/src/main/java/com/furinlab/eightman/uuid_gen/data/local/UuidItemDao.kt
@@ -21,6 +21,9 @@ interface UuidItemDao {
     @Query("DELETE FROM uuid_items WHERE id = :id")
     suspend fun deleteById(id: String)
 
+    @Query("SELECT EXISTS(SELECT 1 FROM uuid_items WHERE value = :value LIMIT 1)")
+    suspend fun existsByValue(value: String): Boolean
+
     @Query("DELETE FROM uuid_items")
     suspend fun clear()
 }

--- a/Android/app/src/main/java/com/furinlab/eightman/uuid_gen/data/repository/DefaultUuidRepository.kt
+++ b/Android/app/src/main/java/com/furinlab/eightman/uuid_gen/data/repository/DefaultUuidRepository.kt
@@ -41,6 +41,10 @@ class DefaultUuidRepository @Inject constructor(
         uuidItemDao.insert(item.toEntity())
     }
 
+    override suspend fun existsByValue(value: String): Boolean {
+        return uuidItemDao.existsByValue(value)
+    }
+
     override suspend fun delete(id: String) {
         uuidItemDao.deleteById(id)
     }

--- a/Android/app/src/main/java/com/furinlab/eightman/uuid_gen/data/repository/UuidRepository.kt
+++ b/Android/app/src/main/java/com/furinlab/eightman/uuid_gen/data/repository/UuidRepository.kt
@@ -12,6 +12,7 @@ interface UuidRepository {
     val entitlement: Flow<Entitlement>
 
     suspend fun save(item: UuidItem)
+    suspend fun existsByValue(value: String): Boolean
     suspend fun delete(id: String)
     suspend fun addBonusSlot(slot: BonusSlot)
     suspend fun removeExpiredBonus(now: Long)

--- a/Android/app/src/main/java/com/furinlab/eightman/uuid_gen/ui/MainUiState.kt
+++ b/Android/app/src/main/java/com/furinlab/eightman/uuid_gen/ui/MainUiState.kt
@@ -11,6 +11,7 @@ data class MainUiState(
     val nameInput: String = "",
     val formatOptions: UuidFormatOptions = UuidFormatOptions(),
     val generatedValue: String? = null,
+    val showGeneratedDialog: Boolean = false,
     val history: List<UuidItem> = emptyList(),
     val limitState: LimitState = LimitState(isPro = false, baseLimit = 10, bonusActive = 0),
     val canSave: Boolean = true,

--- a/iOS/UUID_Gen/UUID_Gen/UuidStore.swift
+++ b/iOS/UUID_Gen/UUID_Gen/UuidStore.swift
@@ -76,6 +76,12 @@ final class UuidStore: ObservableObject {
     func save(generated: GeneratedUuid, label: String?, formatOptions: UuidFormatOptions) async throws {
         let context = context
         try await context.perform {
+            let request: NSFetchRequest<UuidItemEntity> = UuidItemEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "value == %@", generated.value.uuidString)
+            request.fetchLimit = 1
+            if let _ = try context.fetch(request).first {
+                throw NSError(domain: "UuidStore", code: 2, userInfo: [NSLocalizedDescriptionKey: "このUUIDは既に保存されています。"])
+            }
             let entity = UuidItemEntity(context: context)
             entity.id = generated.id
             entity.value = generated.value.uuidString


### PR DESCRIPTION
## Summary
- replace the Android generate button with a floating action button that shows generated UUIDs in a dialog and surfaces errors via alerts
- prevent saving duplicate UUIDs by checking the repository/store on both platforms before persisting
- refresh the iOS generator UI with a floating + button, popup result alert, and duplicate-save warning

## Testing
- ./gradlew test --console=plain *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f38a2070832288aa6f4f5eada0da