### PR TITLE
Add save button to generated UUID dialogs

### DIFF
--- a/Android/app/src/main/java/com/furinlab/eightman/uuid_gen/ui/MainScreen.kt
+++ b/Android/app/src/main/java/com/furinlab/eightman/uuid_gen/ui/MainScreen.kt
@@ -123,6 +123,17 @@ fun MainScreen(
             AlertDialog(
                 onDismissRequest = onDismissGeneratedDialog,
                 confirmButton = {
+                    TextButton(
+                        onClick = {
+                            onSave()
+                            onDismissGeneratedDialog()
+                        },
+                        enabled = uiState.canSave,
+                    ) {
+                        Text("保存")
+                    }
+                },
+                dismissButton = {
                     TextButton(onClick = onDismissGeneratedDialog) {
                         Text("閉じる")
                     }

--- a/iOS/UUID_Gen/UUID_Gen/Views/GeneratorView.swift
+++ b/iOS/UUID_Gen/UUID_Gen/Views/GeneratorView.swift
@@ -140,6 +140,13 @@ struct GeneratorView: View {
         }
         .alert("生成したUUID", isPresented: $showResultAlert, actions: {
             Button("コピー") { copyResult() }
+            Button("保存") {
+                Task { @MainActor in
+                    await saveCurrent()
+                    showResultAlert = false
+                }
+            }
+            .disabled(!store.limitState.canAdd(currentCount: store.items.count))
             Button("閉じる", role: .cancel) { }
         }, message: {
             Text(formattedValue)
@@ -192,6 +199,10 @@ struct GeneratorView: View {
 
     private func saveCurrent() async {
         guard let generated else { return }
+        guard store.limitState.canAdd(currentCount: store.items.count) else {
+            errorMessage = "保存上限に達しました。"
+            return
+        }
         do {
             try await store.save(generated: generated, label: label.isEmpty ? nil : label, formatOptions: formatOptions)
         } catch {


### PR DESCRIPTION
## Summary
- add a save action to the Android generated UUID dialog and keep close control alongside the existing dismiss button
- add a save button to the iOS generated UUID alert and guard against exceeding the save limit before persisting

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e1f6b4a2b08322932b06859809c4d4