### PR TITLE
Add Material dependency for XML theme

### DIFF
--- a/Android/UUID_Gen/app/build.gradle.kts
+++ b/Android/UUID_Gen/app/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.material)
 
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)


### PR DESCRIPTION
## Summary
- add the Material Components dependency so the XML theme parent Theme.Material3.DayNight.NoActionBar resolves during resource linking

## Testing
- ./gradlew :app:processDebugResources --console plain *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e208f00e4083229e5ddba0d70788b8