### PR TITLE
Add Navigation fragment dependencies to resolve defaultNavHost attribute

### DIFF
--- a/Android/UUID_Gen/app/build.gradle.kts
+++ b/Android/UUID_Gen/app/build.gradle.kts
@@ -64,6 +64,8 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.navigation.fragment.ktx)
+    implementation(libs.androidx.navigation.ui.ktx)
     implementation(libs.material)
 
     implementation(libs.kotlinx.coroutines.core)

--- a/Android/UUID_Gen/gradle/libs.versions.toml
+++ b/Android/UUID_Gen/gradle/libs.versions.toml
@@ -45,6 +45,8 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "composeNavigation" }
+androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "composeNavigation" }
+androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "composeNavigation" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add the Navigation fragment and UI dependencies so the layout's defaultNavHost attribute is recognized
- register the new artifacts in the version catalog for reuse

## Testing
- ./gradlew :app:processDebugResources --console=plain *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e20ad6e1b08322b9fa5ceea6d5c34e