### PR TITLE
Fix Kotlin compile errors in UUID generator and history screen

### DIFF
--- a/Android/UUID_Gen/app/src/main/java/com/furinlab/eightman/uuid_gen/domain/UuidGenerator.kt
+++ b/Android/UUID_Gen/app/src/main/java/com/furinlab/eightman/uuid_gen/domain/UuidGenerator.kt
@@ -45,7 +45,7 @@ object UuidGenerator {
         val bytes = hash.copyOf(16)
         bytes[6] = (bytes[6].toInt() and 0x0F or 0x50).toByte()
         bytes[8] = (bytes[8].toInt() and 0x3F or 0x80).toByte()
-        return UUID.fromByteArray(bytes)
+        return uuidFromByteArray(bytes)
     }
 
     fun uuidV7(nowMillis: Long): UUID {
@@ -65,7 +65,7 @@ object UuidGenerator {
         for (i in 0 until 6) {
             bytes[10 + i] = randomBytes[4 + i]
         }
-        return UUID.fromByteArray(bytes)
+        return uuidFromByteArray(bytes)
     }
 }
 
@@ -82,7 +82,7 @@ private fun UUID.toBytes(): ByteArray {
     return buffer
 }
 
-private fun UUID.Companion.fromByteArray(bytes: ByteArray): UUID {
+private fun uuidFromByteArray(bytes: ByteArray): UUID {
     require(bytes.size == 16)
     var msb = 0L
     var lsb = 0L

--- a/Android/UUID_Gen/app/src/main/java/com/furinlab/eightman/uuid_gen/ui/screens/HistoryScreen.kt
+++ b/Android/UUID_Gen/app/src/main/java/com/furinlab/eightman/uuid_gen/ui/screens/HistoryScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -171,17 +170,22 @@ private fun HistoryItem(
             record.label?.takeIf { it.isNotBlank() }?.let {
                 Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
-            Row(horizontalArrangement = Arrangement.spacedBy(4.dp), verticalAlignment = Alignment.CenterVertically) {
-                IconButton(onClick = onCopy) {
-                    Icon(Icons.Default.ContentCopy, contentDescription = "コピー")
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    IconButton(onClick = onCopy) {
+                        Icon(Icons.Default.ContentCopy, contentDescription = "コピー")
+                    }
+                    IconButton(onClick = onShare) {
+                        Icon(Icons.Default.Share, contentDescription = "共有")
+                    }
+                    IconButton(onClick = onDelete) {
+                        Icon(Icons.Default.Delete, contentDescription = "削除")
+                    }
                 }
-                IconButton(onClick = onShare) {
-                    Icon(Icons.Default.Share, contentDescription = "共有")
-                }
-                IconButton(onClick = onDelete) {
-                    Icon(Icons.Default.Delete, contentDescription = "削除")
-                }
-                Spacer(modifier = Modifier.weight(1f))
                 IconButton(onClick = onDetail) {
                     Icon(Icons.Default.Info, contentDescription = "詳細")
                 }


### PR DESCRIPTION
## Summary
- replace unavailable `UUID.fromByteArray` calls with an internal helper so Kotlin can build custom UUID values
- adjust the history item action row to avoid using the internal Row weight API and keep the detail button aligned to the edge

## Testing
- ./gradlew :app:compileDebugKotlin --no-daemon --console=plain *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e20c7815908322b4eec1086982870b