### PR TITLE
Ensure history summary card spans full width

### DIFF
--- a/Android/UUID_Gen/app/src/main/java/com/furinlab/eightman/uuid_gen/ui/screens/HistoryScreen.kt
+++ b/Android/UUID_Gen/app/src/main/java/com/furinlab/eightman/uuid_gen/ui/screens/HistoryScreen.kt
@@ -111,7 +111,7 @@ private fun SummaryCard(
     onClear: () -> Unit,
     onAddBonus: () -> Unit
 ) {
-    Card {
+    Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Text("保存状況", style = MaterialTheme.typography.titleMedium)
             if (storeState.entitlement.isPro) {


### PR DESCRIPTION
## Summary
- make the saved status card on the Android history screen expand to the full screen width

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e21eef06fc83229025d9174a4eb977